### PR TITLE
Implemented users.lookup, friends.ids and followers.ids

### DIFF
--- a/client.go
+++ b/client.go
@@ -68,6 +68,12 @@ type Client struct {
 	// List services
 	Lists *ListService
 
+	// Friend services
+	Friends *FriendsService
+
+	// Followers services
+	Followers *FollowersService
+
 	// API base endpoint. This is the base endpoing URL for API calls. This
 	// can be overwritten by an application that needs to use a different
 	// version of the library or maybe a mock.
@@ -107,6 +113,8 @@ func constructClient(httpClient *http.Client, bearerToken string) *Client {
 	c.Search = &SearchService{c}
 	c.User = &UserService{c}
 	c.Lists = &ListService{c}
+	c.Friends = &FriendsService{c}
+	c.Followers = &FollowersService{c}
 	c.Endpoint = "https://api.twitter.com/1.1"
 	c.ApplicationToken = bearerToken
 	return c

--- a/friends.go
+++ b/friends.go
@@ -17,7 +17,7 @@ type Cursor struct {
 	NextStr     string  `json:"next_cursor_str"`
 	Previous    int64   `json:"previous_cursor"`
 	PreviousStr string  `json:"previous_cursor_str"`
-	Ids         []int64 `json:"ids"`
+	IDs         []int64 `json:"ids"`
 }
 
 // IDs returns a cursored collection of user IDs.

--- a/friends.go
+++ b/friends.go
@@ -1,0 +1,67 @@
+// tweetlib - A fully oauth-authenticated Go Twitter library
+//
+// Copyright 2011 The Tweetlib Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tweetlib
+
+import "strconv"
+
+type FriendsService struct {
+	*Client
+}
+
+type Cursor struct {
+	Next        int64   `json:"next_cursor"`
+	NextStr     string  `json:"next_cursor_str"`
+	Previous    int64   `json:"previous_cursor"`
+	PreviousStr string  `json:"previous_cursor_str"`
+	Ids         []int64 `json:"ids"`
+}
+
+// IDs returns a cursored collection of user IDs.
+// See https://dev.twitter.com/docs/api/1.1/get/friends/ids
+func (ls *FriendsService) IDs(screenName string, userID int64, cursor int64, opts *Optionals) (IDs *Cursor, err error) {
+	if opts == nil {
+		opts = NewOptionals()
+	}
+	switch {
+	case screenName != "":
+		opts.Add("screen_name", screenName)
+	default:
+		opts.Add("user_id", userID)
+	}
+	if cursor != 0 {
+		opts.Add("cursor", strconv.FormatInt(cursor, 10))
+	}
+	IDs = &Cursor{}
+	err = ls.Call("GET", "friends/ids", opts, IDs)
+	return
+}
+
+type FollowersService struct {
+	*Client
+}
+
+// IDs returns a cursored collection of user IDs.
+// See https://dev.twitter.com/docs/api/1.1/get/followers/ids
+func (ls *FollowersService) IDs(screenName string, userID int64, cursor int64, opts *Optionals) (IDs *Cursor, err error) {
+	if opts == nil {
+		opts = NewOptionals()
+	}
+	switch {
+	case screenName != "":
+		opts.Add("screen_name", screenName)
+	default:
+		opts.Add("user_id", userID)
+	}
+	if cursor != 0 {
+		opts.Add("cursor", strconv.FormatInt(cursor, 10))
+	}
+	IDs = &Cursor{}
+	err = ls.Call("GET", "followers/ids", opts, IDs)
+	return
+}
+
+// https://dev.twitter.com/docs/api/1.1/get/followers/ids

--- a/user.go
+++ b/user.go
@@ -111,6 +111,6 @@ func (us *UserService) Lookup(screenNames []string, userIDs []int64, opts *Optio
 	}
 
 	users = &UserList{}
-	err = us.Call("GET", "users/lookup", opts, users)
+	err = us.Call("POST", "users/lookup", opts, users)
 	return
 }

--- a/user.go
+++ b/user.go
@@ -80,7 +80,9 @@ func (us *UserService) Show(screenName string, opts *Optionals) (user *User, err
 	if opts == nil {
 		opts = NewOptionals()
 	}
-	opts.Add("screen_name", screenName)
+	if screenName != "" {
+		opts.Add("screen_name", screenName)
+	}
 	user = &User{}
 	err = us.Call("GET", "users/show", opts, user)
 	return


### PR DESCRIPTION
Implemented users.lookup which takes either an array of screen names :

``` go
ul, err := client.User.Lookup([]string{"jack", "verified"}, nil, opts)
```

or an array of Ids:

``` go
ul, err := client.User.Lookup(nil, []int64{12, 63796828}, opts)
```
